### PR TITLE
Added Code Coverage to See Accuracy of Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,12 @@ before_install:
 
 install:
     - pip install -r requirements.txt
+    - pip install codecov # codecov isn't really part of our project, just
+                          # a useful metric
 
 script:
     - flake8 .
-    - nosetests . -v
+    - nosetests . -v --with-coverage
+
+after_success:
+    - codecov

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # File Checker
-[![Build Status](https://travis-ci.org/iattempt/FileChecker.svg?branch=master)](https://travis-ci.org/iattempt/FileChecker) [![codecov](https://codecov.io/gh/iattempt/FileChecker/branch/master/graph/badge.svg)](https://codecov.io/gh/iattempt/FileChecker)
+[![Build Status](https://travis-ci.org/iattempt/FileChecker.svg?branch=master)](https://travis-ci.org/iattempt/FileChecker) [![codecov](https://codecov.io/gh/iattempt/FileChecker/branch/dev/graph/badge.svg)](https://codecov.io/gh/iattempt/FileChecker)
 
 
 A checker/detector could check name of file/directory is expectable or not.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # File Checker
-[![Build Status](https://travis-ci.org/iattempt/FileChecker.svg?branch=master)](https://travis-ci.org/iattempt/FileChecker) [![codecov](https://codecov.io/gh/iattempt/FileChecker/branch/dev/graph/badge.svg)](https://codecov.io/gh/iattempt/FileChecker)
+[![Build Status](https://travis-ci.org/iattempt/FileChecker.svg?branch=master)](https://travis-ci.org/iattempt/FileChecker) [![codecov](https://codecov.io/gh/iattempt/FileChecker/branch/master/graph/badge.svg)](https://codecov.io/gh/iattempt/FileChecker)
 
 
 A checker/detector could check name of file/directory is expectable or not.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # File Checker
-[![Build Status](https://travis-ci.org/iattempt/FileChecker.svg?branch=master)](https://travis-ci.org/iattempt/FileChecker)
+[![Build Status](https://travis-ci.org/iattempt/FileChecker.svg?branch=master)](https://travis-ci.org/iattempt/FileChecker) [![codecov](https://codecov.io/gh/iattempt/FileChecker/branch/master/graph/badge.svg)](https://codecov.io/gh/iattempt/FileChecker)
+
 
 A checker/detector could check name of file/directory is expectable or not.


### PR DESCRIPTION
Code coverage is an _extremely_ useful metric that allows us to see how many lines of code our tests have covered. So I suggest we add it!